### PR TITLE
Externalize configuration

### DIFF
--- a/configuration/.env.development
+++ b/configuration/.env.development
@@ -1,3 +1,14 @@
 PORT=3000
 MONGO_URI=mongodb://localhost:27017/vre_level
 NODE_ENV=development
+SESSION_SECRET=dev-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=localhost:3000
+JWT_CERTS_URL=http://localhost:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://localhost:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend
+

--- a/configuration/.env.production
+++ b/configuration/.env.production
@@ -1,3 +1,14 @@
 PORT=8080
 MONGO_URI=mongodb+srv://prod_user:prod_pass@cluster.mongodb.net/proddb
 NODE_ENV=production
+SESSION_SECRET=prod-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=localhost:8080
+JWT_CERTS_URL=http://localhost:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://localhost:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend
+

--- a/configuration/.env.test
+++ b/configuration/.env.test
@@ -1,0 +1,14 @@
+PORT=3001
+MONGO_URI=mongodb://localhost:27017/vre_level_test
+NODE_ENV=test
+SESSION_SECRET=test-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=localhost:3001
+JWT_CERTS_URL=http://localhost:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://localhost:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend
+

--- a/configuration/.env.uat
+++ b/configuration/.env.uat
@@ -1,0 +1,14 @@
+PORT=3002
+MONGO_URI=mongodb://localhost:27017/vre_level_uat
+NODE_ENV=uat
+SESSION_SECRET=uat-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=localhost:3002
+JWT_CERTS_URL=http://localhost:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://localhost:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend
+

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,24 @@
 Service to manage Readiness Levels for Virtual Research Environments.
+
+## Configuration
+
+Runtime values are read from environment variables. Example configuration files
+are provided in the `configuration` folder:
+
+```
+PORT=3000
+MONGO_URI=mongodb://localhost:27017/vre_level
+NODE_ENV=development
+SESSION_SECRET=dev-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=localhost:3000
+JWT_CERTS_URL=http://localhost:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://localhost:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend
+```
+
+Adjust the values as needed for your environment.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,7 +6,23 @@ dotenv.config({
 });
 
 export const config = {
-  port: process.env.PORT || 3000,
+  port: Number(process.env.PORT) || 3000,
   mongoUri: process.env.MONGO_URI || '',
   nodeEnv: process.env.NODE_ENV || 'development',
+  sessionSecret: process.env.SESSION_SECRET || 'some-secret',
+  keycloak: {
+    realm: process.env.KEYCLOAK_REALM || 'vre',
+    authServerUrl: process.env.KEYCLOAK_URL || 'http://localhost:8080/auth',
+    sslRequired: process.env.KEYCLOAK_SSL_REQUIRED || 'external',
+    resource: process.env.KEYCLOAK_RESOURCE || 'lab_repository',
+    confidentialPort: Number(process.env.KEYCLOAK_CONFIDENTIAL_PORT) || 0,
+  },
+  swaggerHost: process.env.SWAGGER_HOST || `localhost:${process.env.PORT || 3000}`,
+  jwt: {
+    jwksUri:
+      process.env.JWT_CERTS_URL ||
+      'http://localhost:8080/realms/vre/protocol/openid-connect/certs',
+    issuer: process.env.JWT_ISSUER || 'http://localhost:8080/realms/vre',
+    audience: process.env.JWT_AUDIENCE || 'nextjs-frontend',
+  },
 };

--- a/src/config/keycloak.ts
+++ b/src/config/keycloak.ts
@@ -1,14 +1,15 @@
 import Keycloak from 'keycloak-connect';
 import session from 'express-session';
+import { config } from './config';
 
 const memoryStore = new session.MemoryStore();
 
 const keycloak = new Keycloak({ store: memoryStore }, {
-  "realm": "vre",
-  "auth-server-url": "http://localhost:8080/auth",
-  "ssl-required": "external",
-  "resource": "lab_repository",
-  "confidential-port": 0
+  realm: config.keycloak.realm,
+  'auth-server-url': config.keycloak.authServerUrl,
+  'ssl-required': config.keycloak.sslRequired,
+  resource: config.keycloak.resource,
+  'confidential-port': config.keycloak.confidentialPort,
 });
 
 export { keycloak, memoryStore };

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,4 +1,5 @@
 import swaggerAutogen from 'swagger-autogen';
+import { config } from './config';
 
 const doc = {
   info: {
@@ -6,7 +7,7 @@ const doc = {
     description: 'API documentation with swagger-autogen',
     version: '1.0.0',
   },
-  host: 'localhost:3000',
+  host: config.swaggerHost,
   schemes: ['http'],
   tags: [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,11 @@ import taskDefinitionRoutes from './auto_assess/routes/taskDefinition.routes';
 
 
 const app = express();
-const PORT = 3000;
 
 app.use(cors());
 app.use(
   session({
-    secret: 'some-secret',
+    secret: config.sessionSecret,
     resave: false,
     saveUninitialized: true,
     store: memoryStore,

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -1,9 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { config } from '../config/config';
 
-const jwks = createRemoteJWKSet(
-  new URL('http://localhost:8080/realms/vre/protocol/openid-connect/certs')
-);
+const jwks = createRemoteJWKSet(new URL(config.jwt.jwksUri));
 
 export async function authenticate(req: Request, res: Response, next: NextFunction): Promise<void> {
   const authHeader = req.headers.authorization;
@@ -17,14 +16,15 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
 
   try {
     const { payload } = await jwtVerify(token, jwks, {
-      issuer: 'http://localhost:8080/realms/vre',
-      audience: 'nextjs-frontend',
+      issuer: config.jwt.issuer,
+      audience: config.jwt.audience,
     });
 
     // Attach user info for later use
     (req as any).user = payload;
 
-    const roles = (req as any).user?.resource_access?.['nextjs-frontend']?.roles || [];
+    const roles =
+      (req as any).user?.resource_access?.[config.jwt.audience]?.roles || [];
     if (roles.includes('coordinator')) {
     // show or allow coordinator actions
     }


### PR DESCRIPTION
## Summary
- externalize Express port and session secret settings
- move Keycloak, Swagger and JWT configuration to env variables
- document environment variables

## Testing
- `npm run typecheck` *(fails: Cannot find module 'mongoose')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865525cac58832b97edb0111b7a7fa7