### PR TITLE
feat: add docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+
+# Build output
+build
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use official Node.js image as base
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json tsconfig.json ./
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Use docker-specific environment configuration
+ENV NODE_ENV=docker
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "run", "start"]

--- a/configuration/.env.docker
+++ b/configuration/.env.docker
@@ -1,0 +1,13 @@
+PORT=3000
+MONGO_URI=mongodb://mongo:27017/vre_level
+NODE_ENV=docker
+SESSION_SECRET=dev-secret
+KEYCLOAK_REALM=vre
+KEYCLOAK_URL=http://keycloak:8080/auth
+KEYCLOAK_SSL_REQUIRED=external
+KEYCLOAK_RESOURCE=lab_repository
+KEYCLOAK_CONFIDENTIAL_PORT=0
+SWAGGER_HOST=api:3000
+JWT_CERTS_URL=http://keycloak:8080/realms/vre/protocol/openid-connect/certs
+JWT_ISSUER=http://keycloak:8080/realms/vre
+JWT_AUDIENCE=nextjs-frontend

--- a/readme.md
+++ b/readme.md
@@ -22,3 +22,22 @@ JWT_AUDIENCE=nextjs-frontend
 ```
 
 Adjust the values as needed for your environment.
+
+## Docker
+
+This project includes a `Dockerfile` so the service can run inside a container
+or locally on your machine.
+
+* Running locally uses the settings from `configuration/.env.development`.
+* The Docker image sets `NODE_ENV=docker` and therefore loads
+  `configuration/.env.docker`, which points to Docker&nbsp;Compose service URLs
+  instead of localhost.
+
+To build and run the container:
+
+```bash
+docker build -t vre-levels .
+docker run --env-file configuration/.env.docker -p 3000:3000 vre-levels
+```
+
+Adjust the compose service names in `.env.docker` if your setup differs.


### PR DESCRIPTION
## Summary
- add Dockerfile for containerized runs
- provide docker-specific environment config
- document docker usage and add .dockerignore

## Testing
- `npm run typecheck` *(fails: Property 'id' does not exist and type mismatches)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ca70d9264832b8866a9e11f4bdc38