### PR TITLE
feat: allow fetching labs without specifying role

### DIFF
--- a/src/docs/swagger-output.json
+++ b/src/docs/swagger-output.json
@@ -68,21 +68,11 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "404": {
             "description": "Not Found"
@@ -103,10 +93,17 @@
             }
           },
           {
+            "name": "authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "roleCode",
             "in": "query",
-            "description": "The ObjectId of the user to fetch labs for",
-            "required": true,
+            "description": "Optional role code to filter labs. If omitted, all labs for the user are returned.",
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -115,6 +112,9 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -163,11 +163,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
           },
           "404": {
             "description": "Not Found"
@@ -217,11 +227,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         },
         "requestBody": {
@@ -247,6 +267,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -255,6 +282,9 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         },
         "requestBody": {
@@ -280,6 +310,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -288,6 +325,9 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
           },
           "500": {
             "description": "Internal Server Error"

--- a/src/routes/lab.routes.ts
+++ b/src/routes/lab.routes.ts
@@ -65,13 +65,13 @@ router.get('/:id', async (req, res) => {
 router.get('/by-user/:userId', authenticate,async (req, res) => {
     /*  #swagger.parameters['roleCode'] = {
         in: 'query',
-        description: 'The ObjectId of the user to fetch labs for',
-        required: true,
+        description: 'Optional role code to filter labs. If omitted, all labs for the user are returned.',
+        required: false,
         type: 'string'
     }
 */
 
-    let labs = await labService.getLabsBasedOnRole(req.params['userId'], req.query['roleCode'] as string);
+    let labs = await labService.getLabsBasedOnRole(req.params['userId'], req.query['roleCode']?.toString());
 
     res.status(200).json(labs);
 })

--- a/src/services/labservice.ts
+++ b/src/services/labservice.ts
@@ -90,15 +90,20 @@ export const labService = {
     await config_l1.save();
 
   },currentExitConditions: (data: ILab) => currentExitConditions(data)
-  ,getLabsBasedOnRole: async (user_id:string, role: string) => {
-      const labs = await Lab.find({
+  ,getLabsBasedOnRole: async (user_id:string, role?: string) => {
+      const filter: any = {
         assigned_users: {
           $elemMatch: {
             user_id: user_id,
-            role_codes: role,
           }
         }
-      }).lean();
+      };
+
+      if (role) {
+        filter.assigned_users.$elemMatch.role_codes = role;
+      }
+
+      const labs = await Lab.find(filter).lean();
 
       return labs.map(currentExitConditions);
   },


### PR DESCRIPTION
## Summary
- make role filter optional when retrieving labs for a user
- update lab route and documentation to reflect optional role filter

## Testing
- `npm run swagger`
- `npm run typecheck` *(fails: Property 'id' does not exist on type ...)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a308cc62a4832ba76bb8c1d0cf7fe8